### PR TITLE
Refine Prompt Creation for User-Selected Categories & Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ git commit -m "Describe changes"
 git pull origin <branch>
 git push origin <branch-name>
 ```
+
+## Sprint II Project Updates for Quibble_backend
+1. Refine LLM prompt to improve response content
+- user_input.py (Models): Defines user inputs like selected_categories and user_preference.
+- selected_categories.py (Models): Validates the categories selected by the user and provides default categories if no specific ones are selected.
+- prompt_service.py (Services): Constructs the final prompt using selected categories, user preference, and parsed product details.
+- endpoints.py (API): Integrates all logic to fetch, parse, and create a refined prompt to send to OpenAI based on user input.

--- a/app/models/selected_categories.py
+++ b/app/models/selected_categories.py
@@ -1,0 +1,22 @@
+from typing import List
+
+class SelectedCategories:
+    VALID_CATEGORIES = ["Price", "Model", "Condition", "Features", "Estimated Delivery"]
+
+    @classmethod
+    def validate_categories(cls, categories: List[str]) -> List[str]:
+        """
+        Validates the selected categories by checking if they are in the predefined VALID_CATEGORIES list.
+        Raises a ValueError if any invalid categories are found.
+        """
+        invalid = [category for category in categories if category not in cls.VALID_CATEGORIES]
+        if invalid:
+            raise ValueError(f"Invalid categories: {invalid}")
+        return categories
+
+    @classmethod
+    def get_default_categories(cls) -> List[str]:
+        """
+        Returns a list of default categories to compare products when no specific categories are provided.
+        """
+        return cls.VALID_CATEGORIES

--- a/app/models/user_input.py
+++ b/app/models/user_input.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+from typing import List
+
+class UserInput(BaseModel):
+    selected_categories: List[str]  # Categories selected by the user
+    user_preference: str

--- a/app/services/prompt_service.py
+++ b/app/services/prompt_service.py
@@ -1,0 +1,21 @@
+from app.models.selected_categories import SelectedCategories
+
+def create_prompt(url1_html: str, url2_html: str, selected_categories: list, user_preference: str)-> str:
+
+    # Check empty user input
+    # If no categories are provided, use default categories
+    if not selected_categories:
+        selected_categories = SelectedCategories.get_default_categories()
+    # Check if user preference is empty, provide a default message
+    if not user_preference:
+        user_preference = "No specific preference provided"
+
+     # Build a comparison prompt based on user input and selected categories
+    categories_text = ', '.join(selected_categories)
+    prompt = (
+        f"Compare the following products based on the categories: {categories_text}.\n\n"
+        f"Product 1: {url1_html}\n\nProduct 2: {url2_html}.\n\n"
+        f"User preference: {user_preference}.\n"
+        f"Provide a recommendation based on the selected categories."
+    )
+    return prompt


### PR DESCRIPTION
This PR implements the functionality to refine the prompt sent to OpenAI based on user input from the frontend. 
The code changes happen in the branch of "prompy-tuning"

Key updates include:

- user_input.py: Added fields for selected_categories and user_preference to collect user-specific inputs.
- selected_categories.py: Added category validation and default fallback logic.
- prompt_service.py: Created a method to generate a prompt using parsed HTML, categories, and user preferences.
- endpoints.py: Integrated the refined prompt creation logic for OpenAI API call.

This ensures a customizable comparison based on user input. 

Testing: 
You can test on swagger.  http://127.0.0.1:8000/docs 
![image](https://github.com/user-attachments/assets/6e695370-87df-4ca5-afcf-e31eeb09f1de)

For specific user choice in selected_categories, feel free to provide your feedback to expand the list.  
Current list is in selected_categories.py in models folder, as below:
                           "VALID_CATEGORIES = ["Price", "Model", "Condition", "Features", "Estimated Delivery"]"

For "selected_categories", you can copy - "Price", "Model", "Condition", "Features", "Estimated Delivery"  or add your own input. 
For "user_preference", you can add any thing you want to know or compare about the products. 

