### PR TITLE
fix for failing async chrome driver on attempt 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use python image and install chrome and chromedriver (as opposed to using a pre-built image)
-FROM python:3.11
+FROM python:3.13
 
 # Install prerequisites
 RUN apt-get update && apt-get install -y wget gnupg unzip

--- a/app/services/selenium_pool.py
+++ b/app/services/selenium_pool.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class WebDriverPool:
-    def __init__(self, max_drivers: int = 4):
+    def __init__(self, max_drivers: int = 2):
         self.max_drivers = max_drivers
         self._semaphore = asyncio.Semaphore(max_drivers)
         self._init_lock = asyncio.Lock()

--- a/app/services/selenium_pool.py
+++ b/app/services/selenium_pool.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class WebDriverPool:
-    def __init__(self, max_drivers: int = 2):
+    def __init__(self, max_drivers: int = 4):
         self.max_drivers = max_drivers
         self._semaphore = asyncio.Semaphore(max_drivers)
         self._init_lock = asyncio.Lock()
@@ -106,18 +106,16 @@ class WebDriverPool:
             driver = None
             try:
                 driver = await self._create_driver_with_retry()
-
                 if task_id not in self._active_drivers:
                     self._active_drivers[task_id] = []
                 self._active_drivers[task_id].append(driver)
-
                 yield driver
             finally:
                 if driver:
                     try:
+                        await asyncio.sleep(3)
                         driver.quit()
-                        await asyncio.sleep(0.5)
-
+                        await asyncio.sleep(1)
                         if task_id in self._active_drivers:
                             self._active_drivers[task_id].remove(driver)
                             if not self._active_drivers[task_id]:

--- a/app/services/selenium_pool.py
+++ b/app/services/selenium_pool.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class WebDriverPool:
-    def __init__(self, max_drivers: int = 2):
+    def __init__(self, max_drivers: int = 4):
         self.max_drivers = max_drivers
         self._semaphore = asyncio.Semaphore(max_drivers)
         self._init_lock = asyncio.Lock()
@@ -52,6 +52,11 @@ class WebDriverPool:
         options.add_argument('--no-service-autorun')
         options.add_argument('--password-store=basic')
         options.add_argument('--disable-notifications')
+        options.add_argument('--headless=new')
+        options.add_argument('--disable-blink-features=AutomationControlled')
+        options.add_experimental_option('excludeSwitches', ['enable-automation'])
+        options.add_experimental_option('useAutomationExtension', False)
+        options.add_argument('--start-maximized')
         
         # Random viewport
         viewports = [(1920, 1080), (1366, 768), (1536, 864), (1440, 900)]
@@ -74,7 +79,11 @@ class WebDriverPool:
         
         # Set legitimate referrer
         options.add_argument('--referrer=https://www.google.com/')
-        
+
+        # Unique debugging port to prevent conflicts
+        debug_port = random.randint(9222, 9999)
+        options.add_argument(f'--remote-debugging-port={debug_port}')
+
         return options
 
     async def _create_driver_with_retry(self, max_retries: int = 2) -> webdriver.Chrome:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai==1.47.0
+openai>=1.0.0,<2.0.0
 fastapi
 requests
 beautifulsoup4==4.12.0


### PR DESCRIPTION
This just adds a delay before the drivers quit to ensure that both concurrent chrome drivers complete the scrape